### PR TITLE
feature: 코스 리스트 조회

### DIFF
--- a/src/main/java/com/org/olympiccourse/domain/course/controller/CourseController.java
+++ b/src/main/java/com/org/olympiccourse/domain/course/controller/CourseController.java
@@ -1,7 +1,9 @@
 package com.org.olympiccourse.domain.course.controller;
 
 import com.org.olympiccourse.domain.course.code.CourseResponseCode;
+import com.org.olympiccourse.domain.course.request.CourseSearchCond;
 import com.org.olympiccourse.domain.course.request.CreateCourseRequestDto;
+import com.org.olympiccourse.domain.course.response.CourseListResponseDto;
 import com.org.olympiccourse.domain.course.response.CreateCourseResponseDto;
 import com.org.olympiccourse.domain.course.response.DetailReadCourseResponseDto;
 import com.org.olympiccourse.domain.course.service.CourseService;
@@ -26,6 +28,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class CourseController {
 
     private final CourseService courseService;
+
+    @GetMapping("/courses")
+    public ResponseEntity<ApiResponse<CourseListResponseDto>> getCourseList(@LoginUser User user, CourseSearchCond condition){
+        CourseListResponseDto result = courseService.getCourseList(user, condition);
+        return ResponseEntity.ok(ApiResponse.success(CourseResponseCode.COURSE_GET_SUCCESS, result));
+    }
 
     @PostMapping("/courses")
     public ResponseEntity<ApiResponse<CreateCourseResponseDto>> createCourse(@LoginUser User user,

--- a/src/main/java/com/org/olympiccourse/domain/course/repository/CourseCustomRepository.java
+++ b/src/main/java/com/org/olympiccourse/domain/course/repository/CourseCustomRepository.java
@@ -1,0 +1,12 @@
+package com.org.olympiccourse.domain.course.repository;
+
+import com.org.olympiccourse.domain.course.request.CourseSearchCond;
+import com.org.olympiccourse.domain.course.response.CourseOverviewResponseDto;
+import java.util.List;
+
+public interface CourseCustomRepository {
+
+    List<CourseOverviewResponseDto> findBestThreeCourses(Long userId);
+
+    List<CourseOverviewResponseDto> searchCourseList(Long id, CourseSearchCond condition, int size);
+}

--- a/src/main/java/com/org/olympiccourse/domain/course/repository/CourseCustomRepositoryImpl.java
+++ b/src/main/java/com/org/olympiccourse/domain/course/repository/CourseCustomRepositoryImpl.java
@@ -1,0 +1,103 @@
+package com.org.olympiccourse.domain.course.repository;
+
+import static com.org.olympiccourse.domain.course.entity.QCourse.course;
+import static com.org.olympiccourse.domain.coursephoto.entity.QCoursePhoto.coursePhoto;
+import static com.org.olympiccourse.domain.coursestep.entity.QCourseStep.courseStep;
+import static com.org.olympiccourse.domain.like.entity.QCourseLike.courseLike;
+import static com.org.olympiccourse.domain.tag.entity.QCourseTag.courseTag;
+
+import com.org.olympiccourse.domain.course.request.CourseSearchCond;
+import com.org.olympiccourse.domain.course.response.CourseOverviewResponseDto;
+import com.org.olympiccourse.domain.tag.entity.Tag;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CourseCustomRepositoryImpl implements CourseCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+
+    @Override
+    public List<CourseOverviewResponseDto> findBestThreeCourses(Long userId) {
+
+        NumberExpression likeCount = courseLike.id.countDistinct();
+
+        BooleanExpression likedExpr = userId == null ? Expressions.FALSE :
+            Expressions.booleanTemplate(
+                "sum(case when {0} = {1} then 1 else 0 end) > 0",
+                courseLike.user.id, userId
+            );
+
+        return jpaQueryFactory.select(Projections.constructor(CourseOverviewResponseDto.class,
+                course.id, coursePhoto.path.max(), course.titleKo, course.user.nickname, likeCount,
+                likedExpr))
+            .from(course)
+            .join(courseStep).on(courseStep.course.eq(course))
+            .join(coursePhoto).on(coursePhoto.courseStep.eq(courseStep)
+                .and(coursePhoto.isRep.isTrue()))
+            .leftJoin(courseLike).on(courseLike.course.eq(course))
+            .where(course.secret.isFalse())
+            .groupBy(course.id)
+            .orderBy(likeCount.desc(), course.id.desc())
+            .limit(3)
+            .fetch();
+    }
+
+    @Override
+    public List<CourseOverviewResponseDto> searchCourseList(Long userId, CourseSearchCond condition,
+        int size) {
+        NumberExpression likeCount = courseLike.id.countDistinct();
+
+        BooleanExpression likedExpr = (userId == null) ? Expressions.FALSE :
+            Expressions.booleanTemplate(
+                "sum(case when {0} = {1} then 1 else 0 end) > 0",
+                courseLike.user.id, userId
+            );
+
+        return jpaQueryFactory.select(Projections.constructor(CourseOverviewResponseDto.class,
+                course.id, coursePhoto.path.max(), course.titleKo, course.user.nickname, likeCount,
+                likedExpr))
+            .from(course)
+            .join(courseStep).on(courseStep.course.eq(course))
+            .join(coursePhoto).on(coursePhoto.courseStep.eq(courseStep)
+                .and(coursePhoto.isRep.isTrue()))
+            .leftJoin(courseLike).on(courseLike.course.eq(course))
+            .leftJoin(courseTag).on(courseTag.course.eq(course))
+            .where(
+                keywordCond(condition.keyword()),
+                tagsCond(condition.tags()),
+                cursorCond(condition.cursor()),
+                course.secret.isFalse()
+            )
+            .groupBy(course.id)
+            .orderBy(course.id.desc())
+            .limit(size + 1)
+            .fetch();
+    }
+
+    private BooleanExpression keywordCond(String keyword) {
+        return (keyword != null && !keyword.isBlank())
+            ? course.titleKo.contains(keyword)
+            : null;
+    }
+
+    private BooleanExpression tagsCond(List<Tag> tags) {
+        return (tags != null && !tags.isEmpty())
+            ? courseTag.tag.in(tags)
+            : null;
+    }
+
+    private BooleanExpression cursorCond(Long cursor) {
+        return cursor != null
+            ? course.id.lt(cursor)
+            : null;
+    }
+}

--- a/src/main/java/com/org/olympiccourse/domain/course/request/CourseSearchCond.java
+++ b/src/main/java/com/org/olympiccourse/domain/course/request/CourseSearchCond.java
@@ -1,0 +1,12 @@
+package com.org.olympiccourse.domain.course.request;
+
+import com.org.olympiccourse.domain.tag.entity.Tag;
+import java.util.List;
+
+public record CourseSearchCond(
+    String keyword,
+    List<Tag> tags,
+    Long cursor
+    ) {
+
+}

--- a/src/main/java/com/org/olympiccourse/domain/course/response/CourseListResponseDto.java
+++ b/src/main/java/com/org/olympiccourse/domain/course/response/CourseListResponseDto.java
@@ -1,0 +1,13 @@
+package com.org.olympiccourse.domain.course.response;
+
+
+import java.util.List;
+
+public record CourseListResponseDto (
+    List<CourseOverviewResponseDto> bestCourses,
+    List<CourseOverviewResponseDto> courses,
+    Long nextCursor,
+    boolean isLast
+){
+
+}

--- a/src/main/java/com/org/olympiccourse/domain/course/response/CourseOverviewResponseDto.java
+++ b/src/main/java/com/org/olympiccourse/domain/course/response/CourseOverviewResponseDto.java
@@ -1,0 +1,25 @@
+package com.org.olympiccourse.domain.course.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class CourseOverviewResponseDto {
+
+    Long courseId;
+
+    String thumbnail;
+
+    String title;
+
+    String writer;
+
+    Long likeNum;
+
+    Boolean liked;
+}

--- a/src/main/java/com/org/olympiccourse/domain/tag/entity/Tag.java
+++ b/src/main/java/com/org/olympiccourse/domain/tag/entity/Tag.java
@@ -12,10 +12,8 @@ public enum Tag {
     SUNNY,
     RAIN,
     WINDY,
-
     COLD,
     HOT,
-    FINE_DUST,
 
     ON_FOOT,
     PUBLIC_TRANSPORT,

--- a/src/main/java/com/org/olympiccourse/global/config/SecurityConfig.java
+++ b/src/main/java/com/org/olympiccourse/global/config/SecurityConfig.java
@@ -62,6 +62,7 @@ public class SecurityConfig {
                 ).permitAll()
                 // 코스
                 .requestMatchers(HttpMethod.GET, "/api/courses/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/courses").permitAll()
                 .anyRequest().authenticated()
             );
 

--- a/src/main/java/com/org/olympiccourse/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/org/olympiccourse/global/security/filter/JwtAuthorizationFilter.java
@@ -30,7 +30,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         "/api/auth/login", "/api/users", "/api/users/check"
     );
 
-    private final Set<String> excludeGetPaths = Set.of("/api/courses/**");
+    private final Set<String> excludeGetPaths = Set.of("/api/courses/**", "/api/courses");
 
     public JwtAuthorizationFilter(JwtUtil jwtUtil) {
         this.jwtUtil = jwtUtil;


### PR DESCRIPTION
## 📝 memo
- **무한 스크롤 구현**
  - `limit(size + 1)` :조회하려는 사이즈보다 1개 더 많이 요청함
  - 반환된 데이터가 `size`값보다 큰지 작은지를 비교 => **다음 반환할 데이터가 존재하는지 파악**
  - 반환된 데이터 리스트에서 마지막 index에 위치한 값의 id를 반환 => `cursor`
  ➜ 다음 요청 시, 어디부터 데이터를 전달할지 파악하는 요소

- **join과 left join**
  - course에 항상 존재할 `courseStep`, `coursePhoto`는 **inner join**
  - 없을 가능성이 있는 `courseLike`, `courseTag`는 **left join**
    - `courseLike가 없는 경우` : 아무도 좋아요를 누르지 않은 경우
    - `courseTag가 없는 경우` : 작성자가 태그를 설정하지 않은 경우

- **group by**
  - `courseId`를 기준으로 데이터를 그룹화함. (`courseId`를 기준으로 중복 행 제거)
  - 이 때 `coursePhoto.path`에 집계 함수를 넣어 중복 행을 없애주는 과정이 필요함.
  - 중복 행이 있다면, 어떤 기준으로 다른 행을 제거할지 모르기 때문에..
  ➜ 조인을 하면서 중복 행이 생김.
  - **`course.titleKo`, `course.user.nickname`에는 집약함수를 사용하지 않은 이유?**
    - `course.titleKo`는 필드, `course.user.nickname`은 **함수적으로 종속**되어 있음
  - `likeCount`와 `likedExpr`는 이미 집계 함수를 사용한 상태라 필요 없음.
  - `coursePhoto`의 경우, `courseStep`을 매개로 연관관계를 맺고 있기 때문에 집계함수가 필요함. (종속되어 있지 않아 `courseId`로 `coursePhoto`를 결정할 수 없음)


- **BooleanExpression**
  - `BooleanExpression` : 조건을 표현
    - **조건이 있을 때**는 where 절에 포함
    - **조건이 없을 때(null)**면 아예 where에서 제외
  ➜ 필요한 조건만 적용하는 동적 쿼리를 만들 수 있음.