### PR TITLE
fix/#75 베스트 코스 쿼리 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,8 +61,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.springframework.security:spring-security-test'
-    testImplementation "org.testcontainers:junit-jupiter:1.17.2"
-    testImplementation "org.testcontainers:mysql:1.17.2"
+    testImplementation "org.testcontainers:junit-jupiter:1.20.4"
+    testImplementation "org.testcontainers:mysql"
+    testRuntimeOnly "com.mysql:mysql-connector-j:8.4.0"
 
     // aws
     implementation platform("software.amazon.awssdk:bom:2.31.70")

--- a/src/main/java/com/org/olympiccourse/domain/course/repository/CourseCustomRepository.java
+++ b/src/main/java/com/org/olympiccourse/domain/course/repository/CourseCustomRepository.java
@@ -4,11 +4,12 @@ import com.org.olympiccourse.domain.course.request.CourseSearchCond;
 import com.org.olympiccourse.domain.course.request.MyCourseVisibility;
 import com.org.olympiccourse.domain.course.response.CourseOverviewResponseDto;
 import com.org.olympiccourse.domain.course.response.CourseOverviewTagResponseDto;
+import java.time.LocalDate;
 import java.util.List;
 
 public interface CourseCustomRepository {
 
-    List<CourseOverviewResponseDto> findBestThreeCourses(Long userId);
+    List<CourseOverviewResponseDto> findBestThreeCourses(Long userId, LocalDate now);
 
     List<CourseOverviewResponseDto> searchCourseList(Long id, CourseSearchCond condition, int size);
 

--- a/src/main/java/com/org/olympiccourse/domain/course/repository/CourseCustomRepositoryImpl.java
+++ b/src/main/java/com/org/olympiccourse/domain/course/repository/CourseCustomRepositoryImpl.java
@@ -11,11 +11,17 @@ import com.org.olympiccourse.domain.course.request.MyCourseVisibility;
 import com.org.olympiccourse.domain.course.response.CourseOverviewResponseDto;
 import com.org.olympiccourse.domain.course.response.CourseOverviewTagResponseDto;
 import com.org.olympiccourse.domain.tag.entity.Tag;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -26,29 +32,38 @@ public class CourseCustomRepositoryImpl implements CourseCustomRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
-
     @Override
-    public List<CourseOverviewResponseDto> findBestThreeCourses(Long userId) {
+    public List<CourseOverviewResponseDto> findBestThreeCourses(Long userId, LocalDate now) {
 
-        NumberExpression likeCount = getLikeCount();
+        LocalDateTime start = now.withDayOfMonth(1).atStartOfDay();
+        LocalDateTime end = now.plusMonths(1).withDayOfMonth(1).atStartOfDay();
 
-        BooleanExpression likedExpr = userId == null ? Expressions.FALSE :
-            Expressions.booleanTemplate(
-                "sum(case when {0} = {1} then 1 else 0 end) > 0",
-                courseLike.user.id, userId
+        // 좋아요 개수
+        Expression<Long> likeCount = courseLike.id.count();
+
+        // 대표사진
+        Expression<String> thumbnail = JPAExpressions.select(coursePhoto.path.max())
+            .from(coursePhoto)
+            .join(coursePhoto.courseStep, courseStep)
+            .where(
+                courseStep.course.eq(course)
+                    .and(coursePhoto.isRep.isTrue())
             );
 
+        // 사용자의 좋아요 여부
+        BooleanExpression likedExpr = getLikedExpr(userId);
+
         return jpaQueryFactory.select(Projections.constructor(CourseOverviewResponseDto.class,
-                course.id, coursePhoto.path.max(), course.titleKo, course.user.nickname, likeCount,
+                course.id, thumbnail, course.titleKo, course.user.nickname, likeCount,
                 likedExpr))
             .from(course)
-            .join(courseStep).on(courseStep.course.eq(course))
-            .leftJoin(coursePhoto).on(coursePhoto.courseStep.eq(courseStep)
-                .and(coursePhoto.isRep.isTrue()))
-            .leftJoin(courseLike).on(courseLike.course.eq(course))
-            .where(course.secret.isFalse())
-            .groupBy(course.id)
-            .orderBy(likeCount.desc(), course.id.desc())
+            .join(courseLike).on(courseLike.course.eq(course))
+            .where(course.secret.isFalse(),
+                course.createdAt.goe(start),
+                course.createdAt.lt(end)
+                )
+            .groupBy(course.id, course.titleKo, course.user.nickname)
+            .orderBy(new OrderSpecifier<>(Order.DESC, likeCount), course.id.desc())
             .limit(3)
             .fetch();
     }
@@ -79,16 +94,15 @@ public class CourseCustomRepositoryImpl implements CourseCustomRepository {
 
     private BooleanExpression getLikedExpr(Long userId) {
         BooleanExpression likedExpr = (userId == null) ? Expressions.FALSE :
-            Expressions.booleanTemplate(
-                "sum(case when {0} = {1} then 1 else 0 end) > 0",
-                courseLike.user.id, userId
-            );
+            new CaseBuilder().when(courseLike.user.id.eq(userId)).then(1)
+                .otherwise(0).sum().gt(0);
         return likedExpr;
     }
 
-    private NumberExpression getLikeCount() {
-        NumberExpression likeCount = courseLike.id.countDistinct();
-        return likeCount;
+    private Expression<Long> getLikeCount() {
+        return JPAExpressions.select(courseLike.id.count())
+            .from(courseLike)
+            .where(courseLike.course.eq(course));
     }
 
     @Override

--- a/src/main/java/com/org/olympiccourse/domain/course/service/CourseService.java
+++ b/src/main/java/com/org/olympiccourse/domain/course/service/CourseService.java
@@ -26,6 +26,8 @@ import com.org.olympiccourse.domain.tag.repository.CourseTagRepository;
 import com.org.olympiccourse.domain.tag.response.CourseTagProjection;
 import com.org.olympiccourse.domain.user.entity.User;
 import com.org.olympiccourse.global.response.CustomException;
+import java.time.Clock;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +50,7 @@ public class CourseService {
     private final CourseStepRepository courseStepRepository;
     private final LikeRepository likeRepository;
     private final CourseCustomRepository courseCustomRepository;
+    private final Clock clock;
     private static final int DEFAULT_PAGE_SIZE = 20;
 
     public CreateCourseResponseDto create(User user, CreateCourseRequestDto request) {
@@ -235,8 +238,10 @@ public class CourseService {
 
         Long userId = (user == null) ? null : user.getId();
 
+        LocalDate now = LocalDate.now(clock);
+
         // 베스트 3 코스
-        List<CourseOverviewResponseDto> bests = getBestCourses(userId);
+        List<CourseOverviewResponseDto> bests = getBestCourses(userId, now);
 
         // 조회
         List<CourseOverviewResponseDto> courses = courseCustomRepository.searchCourseList(userId,
@@ -257,8 +262,8 @@ public class CourseService {
         return new CourseListResponseDto(bests, returnCourses, nextCursor, isLast);
     }
 
-    public List<CourseOverviewResponseDto> getBestCourses(Long userId) {
-        return courseCustomRepository.findBestThreeCourses(userId);
+    public List<CourseOverviewResponseDto> getBestCourses(Long userId, LocalDate now) {
+        return courseCustomRepository.findBestThreeCourses(userId, now);
     }
 
     public CourseSimpleListWithTagResponseDto getWrittenCourses(User user,

--- a/src/main/java/com/org/olympiccourse/domain/home/service/HomeService.java
+++ b/src/main/java/com/org/olympiccourse/domain/home/service/HomeService.java
@@ -50,8 +50,9 @@ public class HomeService {
             .build();
 
         Long userId = (user != null) ? user.getId() : null;
-        HomeEventResponse eventData = eventService.getEventData(LocalDate.now(clock));
-        List<CourseOverviewResponseDto> bestCourses = courseService.getBestCourses(userId);
+        LocalDate now = LocalDate.now(clock);
+        HomeEventResponse eventData = eventService.getEventData(now);
+        List<CourseOverviewResponseDto> bestCourses = courseService.getBestCourses(userId, now);
         return new HomeResponse(weatherIntegrationData, eventData, bestCourses);
 
     }

--- a/src/main/java/com/org/olympiccourse/domain/like/controller/LikeController.java
+++ b/src/main/java/com/org/olympiccourse/domain/like/controller/LikeController.java
@@ -11,7 +11,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController

--- a/src/test/java/com/org/olympiccourse/OlympicCourseApplicationTests.java
+++ b/src/test/java/com/org/olympiccourse/OlympicCourseApplicationTests.java
@@ -1,8 +1,11 @@
 package com.org.olympiccourse;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class OlympicCourseApplicationTests {
 

--- a/src/test/java/com/org/olympiccourse/course/CourseRepositoryImplTest.java
+++ b/src/test/java/com/org/olympiccourse/course/CourseRepositoryImplTest.java
@@ -1,0 +1,97 @@
+package com.org.olympiccourse.course;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.org.olympiccourse.domain.course.entity.Course;
+import com.org.olympiccourse.domain.course.repository.CourseCustomRepository;
+import com.org.olympiccourse.domain.course.repository.CourseCustomRepositoryImpl;
+import com.org.olympiccourse.domain.course.response.CourseOverviewResponseDto;
+import com.org.olympiccourse.domain.user.entity.User;
+import com.org.olympiccourse.global.config.QuerydslConfig;
+import com.org.olympiccourse.support.TestEntityFactory;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({QuerydslConfig.class, CourseCustomRepositoryImpl.class})
+class CourseRepositoryImplTest {
+
+    @Autowired
+    EntityManager em;
+    @Autowired
+    CourseCustomRepository courseRepository;
+
+    TestEntityFactory f;
+
+    @BeforeEach
+    void setUp() {
+        f = new TestEntityFactory(em);
+    }
+
+    @Test
+    void findBestThreeCourses_ordersByLikeCount_andSetsLiked_andFiltersThisMonth() {
+        // given
+        LocalDate now = LocalDate.of(2026, 3, 4);
+        LocalDateTime thisMonth = now.withDayOfMonth(2).atStartOfDay();
+        LocalDateTime lastMonth = now.minusMonths(1).withDayOfMonth(15).atStartOfDay();
+
+        User owner = f.user("owner");
+        User me = f.user("me");
+
+        // 이번 달 공개 코스 4개
+        Course c1 = f.course(owner, "c1", false, thisMonth);
+        f.courseStepWithRepPhoto(c1, 1);
+        f.likes(c1, 5);
+        f.courseLike(c1, me);
+
+        Course c2 = f.course(owner,  "c2", false, thisMonth.plusDays(1));
+        f.courseStepWithRepPhoto(c2, 1);
+        f.likes(c2, 3);
+
+        Course c3 = f.course(owner, "c3", false, thisMonth.plusDays(2));
+        f.courseStepWithRepPhoto(c3, 1);
+        f.likes(c3, 1);
+
+        Course c4 = f.course(owner, "c4", false, thisMonth.plusDays(3));
+        f.courseStepWithRepPhoto(c4, 1);
+
+        // 지난달 코스
+        Course old = f.course(owner, "old", false, lastMonth);
+        f.courseStepWithRepPhoto(old, 1);
+        f.likes(old, 100);
+
+        // 비공개 코스
+        Course secret = f.course(owner, "secret", true, thisMonth);
+        f.courseStepWithRepPhoto(secret, 1);
+        f.likes(secret, 100);
+
+        f.flushAndClear();
+
+        // when
+        List<CourseOverviewResponseDto> result =
+            courseRepository.findBestThreeCourses(me.getId(), now);
+
+        // then
+        assertThat(result).hasSize(3);
+
+        // 좋아요 순
+        assertThat(result.get(0).getCourseId()).isEqualTo(c1.getId());
+        assertThat(result.get(1).getCourseId()).isEqualTo(c2.getId());
+        assertThat(result.get(2).getCourseId()).isEqualTo(c3.getId());
+
+        // 사용자의 좋아요 여부
+        assertThat(result.get(0).getLiked()).isTrue();
+        assertThat(result.get(1).getLiked()).isFalse();
+        assertThat(result.get(2).getLiked()).isFalse();
+    }
+}

--- a/src/test/java/com/org/olympiccourse/support/TestEntityFactory.java
+++ b/src/test/java/com/org/olympiccourse/support/TestEntityFactory.java
@@ -1,0 +1,98 @@
+package com.org.olympiccourse.support;
+
+import com.org.olympiccourse.domain.course.entity.Course;
+import com.org.olympiccourse.domain.coursephoto.entity.CoursePhoto;
+import com.org.olympiccourse.domain.coursestep.entity.CourseStep;
+import com.org.olympiccourse.domain.like.entity.CourseLike;
+import com.org.olympiccourse.domain.user.entity.Role;
+import com.org.olympiccourse.domain.user.entity.Status;
+import com.org.olympiccourse.domain.user.entity.User;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class TestEntityFactory {
+
+    private final EntityManager em;
+
+    public TestEntityFactory(EntityManager em) {
+        this.em = em;
+    }
+
+    public User user(String nickname) {
+        UUID uuid = UUID.randomUUID();
+        User user = User.builder()
+            .nickname(nickname + uuid)
+            .email(nickname + uuid + "@test.com")
+            .password("password")
+            .status(Status.ACTIVITY)
+            .role(Role.ROLE_USER)
+            .build();
+
+        em.persist(user);
+        return user;
+    }
+
+    public Course course(User user, String titleKo, boolean secret, LocalDateTime createdAt) {
+        Course course = Course.builder()
+            .titleKo(titleKo)
+            .secret(secret)
+            .user(user)
+            .build();
+
+        em.persist(course);
+
+        ReflectionTestUtils.setField(course, "createdAt", createdAt);
+        return course;
+    }
+
+    public CourseStep courseStep(Course course, int order) {
+        CourseStep cs = CourseStep.builder()
+            .stepOrder(order)
+            .name("step " + order)
+            .longitude(127.0)
+            .latitude(37.0)
+            .course(course)
+            .build();
+
+        em.persist(cs);
+        return cs;
+    }
+
+    public CourseStep courseStepWithRepPhoto(Course course, int order) {
+        CourseStep step = courseStep(course, order);
+
+        CoursePhoto photo = CoursePhoto.builder()
+            .path("/photo/course-step/" + UUID.randomUUID())
+            .isRep(true)
+            .build();
+
+        photo.setStep(step);
+        em.persist(photo);
+        return step;
+    }
+
+    public CourseLike courseLike(Course course, User user) {
+        CourseLike courseLike = CourseLike.builder()
+            .course(course)
+            .user(user)
+            .build();
+
+        em.persist(courseLike);
+        return courseLike;
+    }
+
+    public void likes(Course course, int n) {
+        for (int i = 0; i < n; i++) {
+            User u = user("testnick" + i);
+            courseLike(course, u);
+        }
+    }
+
+    public void flushAndClear() {
+        em.flush();
+        em.clear();
+    }
+
+}


### PR DESCRIPTION
### 변경 사항
- 베스트 코스 조회 쿼리를 수정

### 변경 이유
- 기존에는 전체 코스 중 좋아요 수가 많은 상위 3개의 코스를 조회하고 있었음
- 요구사항에 따라 **해당 달에 생성된 코스 중 좋아요 수가 많은 상위 3개 코스**를 조회하도록 변경
- 기존 쿼리는 `courseStep`, `coursePhoto`, `courseLike` 등을 메인 쿼리에서 함께 조인하면서 row 수가 증가할 수 있는 구조였음.

### 주요 변경 내용
- 좋아요 집계는 `course_like` 조인을 통해 계산하도록 수정
- 대표 썸네일 조회는 상관 서브쿼리로 분리
- 메인 쿼리에서 불필요한 조인을 제거하여 쿼리 구조 단순화